### PR TITLE
新增 KardLeaf 官网与 APK 下载页面

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,281 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#4c7a62" />
+  <meta name="description" content="KardLeaf 卡叶笔记是一款本地优先、轻量简洁的 Android Markdown 笔记应用。" />
+  <meta property="og:title" content="KardLeaf / 卡叶笔记" />
+  <meta property="og:description" content="本地优先的 Android Markdown 笔记应用，让你的文字始终掌握在自己手中。" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://raw.githubusercontent.com/waikr/KardLeaf/main/docs/images/home-cards.jpg" />
+  <title>KardLeaf / 卡叶笔记</title>
+  <link rel="stylesheet" href="./styles.css" />
+  <script src="./script.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">跳到主要内容</a>
+
+  <header class="site-header" id="top">
+    <div class="container nav-shell">
+      <a class="brand" href="#top" aria-label="KardLeaf 首页">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 48 48" role="img">
+            <path d="M11 8.5h18.5c4.7 0 8.5 3.8 8.5 8.5v22.5H19.5C14.8 39.5 11 35.7 11 31V8.5Z" />
+            <path d="M16.5 31.2c7.8-1.2 12.7-5.9 15.2-14.2-8.6.4-14 5.2-15.2 14.2Z" />
+            <path d="M17 32c3.6-4.3 7.3-7.7 12.9-11.4" />
+          </svg>
+        </span>
+        <span class="brand-copy">
+          <strong>KardLeaf</strong>
+          <small>卡叶笔记</small>
+        </span>
+      </a>
+
+      <nav class="desktop-nav" aria-label="主导航">
+        <a href="#features">功能</a>
+        <a href="#screenshots">截图</a>
+        <a href="#download">下载</a>
+        <a href="https://github.com/waikr/KardLeaf" target="_blank" rel="noreferrer">GitHub</a>
+      </nav>
+
+      <div class="nav-actions">
+        <button class="icon-button" id="themeToggle" type="button" aria-label="切换深色模式" title="切换深色模式">
+          <svg class="sun-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v2m0 14v2M3 12h2m14 0h2M5.6 5.6 7 7m10 10 1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" /></svg>
+          <svg class="moon-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.4 14.2A8.5 8.5 0 0 1 9.8 3.6 8.5 8.5 0 1 0 20.4 14.2Z" /></svg>
+        </button>
+        <a class="nav-download" href="https://github.com/waikr/KardLeaf/releases/latest" data-download-link>
+          下载 APK
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="hero">
+      <div class="hero-glow hero-glow-one"></div>
+      <div class="hero-glow hero-glow-two"></div>
+      <div class="container hero-grid">
+        <div class="hero-visual reveal">
+          <div class="visual-orbit orbit-one"></div>
+          <div class="visual-orbit orbit-two"></div>
+          <div class="phone phone-back" aria-hidden="true">
+            <div class="phone-screen">
+              <img src="./images/navigation-drawer.jpg" alt="" />
+            </div>
+          </div>
+          <div class="phone phone-front">
+            <div class="phone-camera" aria-hidden="true"></div>
+            <div class="phone-screen">
+              <img src="./images/home-cards.jpg" alt="KardLeaf 首页卡片界面" />
+            </div>
+          </div>
+          <div class="floating-card floating-card-top">
+            <span class="floating-icon">✓</span>
+            <span><strong>本地优先</strong><small>真实 Markdown 文件</small></span>
+          </div>
+          <div class="floating-card floating-card-bottom">
+            <span class="floating-icon">⌁</span>
+            <span><strong>轻量流畅</strong><small>专注移动端记录</small></span>
+          </div>
+        </div>
+
+        <div class="hero-copy reveal">
+          <div class="eyebrow"><span></span> 为 Android 打造的 Markdown 笔记</div>
+          <h1>把灵感写进<br /><span>真正属于你的文件</span></h1>
+          <p class="hero-description">
+            KardLeaf 是一款本地优先、轻量简洁的 Android Markdown 笔记应用。
+            不强制登录，不锁定格式，让记录、整理与迁移都保持自由。
+          </p>
+
+          <div class="hero-actions">
+            <a class="button button-primary" href="https://github.com/waikr/KardLeaf/releases/latest" data-download-link>
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 19h14" /></svg>
+              <span><small>Android 安装包</small><strong data-download-text>下载最新版 APK</strong></span>
+            </a>
+            <a class="button button-secondary" href="https://github.com/waikr/KardLeaf" target="_blank" rel="noreferrer">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.8a9.2 9.2 0 0 0-2.9 17.9c.5.1.6-.2.6-.5v-1.8c-2.8.6-3.4-1.2-3.4-1.2-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 0 1.6 1.1 1.6 1.1.9 1.6 2.4 1.1 2.9.9.1-.7.4-1.1.7-1.4-2.2-.3-4.6-1.1-4.6-4.9 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.8 1a9.5 9.5 0 0 1 5 0c1.9-1.3 2.8-1 2.8-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.8-2.3 4.6-4.6 4.9.4.3.7.9.7 1.7v2.6c0 .4.2.6.7.5A9.2 9.2 0 0 0 12 2.8Z" /></svg>
+              查看源代码
+            </a>
+          </div>
+
+          <div class="release-meta" aria-live="polite">
+            <span class="status-dot"></span>
+            <span id="releaseStatus">正在获取最新版本信息…</span>
+          </div>
+
+          <div class="hero-badges" aria-label="应用特性">
+            <span>Android 6.0+</span>
+            <span>Apache 2.0</span>
+            <span>Obsidian 兼容</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="trust-strip" aria-label="核心特点">
+      <div class="container trust-grid">
+        <div><strong>本地文件</strong><span>Markdown / TXT</span></div>
+        <div><strong>无需账号</strong><span>打开即可记录</span></div>
+        <div><strong>灵活同步</strong><span>WebDAV / Syncthing</span></div>
+        <div><strong>自由迁移</strong><span>不被应用锁定</span></div>
+      </div>
+    </section>
+
+    <section class="section" id="features">
+      <div class="container">
+        <div class="section-heading reveal">
+          <div>
+            <span class="section-kicker">为什么选择 KardLeaf</span>
+            <h2>轻量，但不简单</h2>
+          </div>
+          <p>保留 Markdown 的自由，同时补齐移动端记录、整理、预览与管理体验。</p>
+        </div>
+
+        <div class="feature-grid">
+          <article class="feature-card feature-card-wide reveal">
+            <span class="feature-number">01</span>
+            <div class="feature-icon">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H18a2 2 0 0 1 2 2v14H6.5A2.5 2.5 0 0 1 4 16.5v-11Z" /><path d="M4 16.5A2.5 2.5 0 0 1 6.5 14H20M8 7h8M8 10h5" /></svg>
+            </div>
+            <h3>本地文件优先</h3>
+            <p>正文保存为真实的 Markdown / TXT 文件。备份、迁移、同步和跨应用编辑都更直接。</p>
+            <div class="mini-code"><span>notes/</span><span>├─ 灵感.md</span><span>└─ 项目/计划.md</span></div>
+          </article>
+
+          <article class="feature-card reveal">
+            <span class="feature-number">02</span>
+            <div class="feature-icon">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h10M4 18h7" /><path d="m16 15 2 2 4-5" /></svg>
+            </div>
+            <h3>实时编辑与预览</h3>
+            <p>常用 Markdown 格式、任务、图片、代码块和公式，写作与检查排版可以快速切换。</p>
+          </article>
+
+          <article class="feature-card reveal">
+            <span class="feature-number">03</span>
+            <div class="feature-icon">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" /></svg>
+            </div>
+            <h3>灵活分类整理</h3>
+            <p>支持多级目录、顶部分类、侧边栏、标签和属性，让小记录与大型笔记库都井然有序。</p>
+          </article>
+
+          <article class="feature-card reveal">
+            <span class="feature-number">04</span>
+            <div class="feature-icon">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 7h10v10H7z" /><path d="M4 12a8 8 0 0 1 8-8M20 12a8 8 0 0 1-8 8" /><path d="m9 2 3 2-2 3M15 22l-3-2 2-3" /></svg>
+            </div>
+            <h3>兼容现有工作流</h3>
+            <p>可以配合 Obsidian、VS Code、Typora、WebDAV 或 Syncthing 使用同一批文件。</p>
+          </article>
+
+          <article class="feature-card feature-card-accent reveal">
+            <span class="feature-number">05</span>
+            <div class="feature-icon">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 5 6v5c0 4.6 2.8 8.1 7 10 4.2-1.9 7-5.4 7-10V6l-7-3Z" /><path d="m9 12 2 2 4-5" /></svg>
+            </div>
+            <h3>隐私由你掌控</h3>
+            <p>不强制注册账号，不强制上传云端。你可以自己决定笔记放在哪里、怎样同步。</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-soft" id="screenshots">
+      <div class="container">
+        <div class="section-heading centered reveal">
+          <span class="section-kicker">界面预览</span>
+          <h2>熟悉、清晰、顺手</h2>
+          <p>从快速记录到长文整理，界面始终围绕内容本身展开。</p>
+        </div>
+
+        <div class="screenshot-tabs" role="tablist" aria-label="截图分类">
+          <button class="screenshot-tab active" type="button" data-filter="all">全部</button>
+          <button class="screenshot-tab" type="button" data-filter="write">编辑</button>
+          <button class="screenshot-tab" type="button" data-filter="manage">管理</button>
+          <button class="screenshot-tab" type="button" data-filter="tools">工具</button>
+        </div>
+
+        <div class="screenshot-grid">
+          <button class="screenshot-card tall reveal" type="button" data-category="manage" data-image="./images/home-cards.jpg" data-title="首页卡片与分类">
+            <img src="./images/home-cards.jpg" alt="首页卡片与分类" loading="lazy" />
+            <span>首页卡片与分类</span>
+          </button>
+          <button class="screenshot-card reveal" type="button" data-category="write" data-image="./images/editor-editing.jpg" data-title="Markdown 编辑器">
+            <img src="./images/editor-editing.jpg" alt="Markdown 编辑器" loading="lazy" />
+            <span>Markdown 编辑器</span>
+          </button>
+          <button class="screenshot-card reveal" type="button" data-category="manage" data-image="./images/navigation-drawer.jpg" data-title="侧边栏导航">
+            <img src="./images/navigation-drawer.jpg" alt="侧边栏导航" loading="lazy" />
+            <span>侧边栏导航</span>
+          </button>
+          <button class="screenshot-card reveal" type="button" data-category="write" data-image="./images/editor-outline-panel.jpg" data-title="文章目录">
+            <img src="./images/editor-outline-panel.jpg" alt="文章目录" loading="lazy" />
+            <span>文章目录</span>
+          </button>
+          <button class="screenshot-card reveal" type="button" data-category="tools" data-image="./images/history.jpg" data-title="历史版本">
+            <img src="./images/history.jpg" alt="历史版本" loading="lazy" />
+            <span>历史版本</span>
+          </button>
+          <button class="screenshot-card reveal" type="button" data-category="tools" data-image="./images/drawing.jpg" data-title="绘图工具">
+            <img src="./images/drawing.jpg" alt="绘图工具" loading="lazy" />
+            <span>绘图工具</span>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="section download-section" id="download">
+      <div class="container download-card reveal">
+        <div class="download-pattern" aria-hidden="true"></div>
+        <div class="download-copy">
+          <span class="section-kicker light">开始使用</span>
+          <h2>让下一条笔记，真正属于你</h2>
+          <p>从 GitHub Releases 获取最新版 APK。安装前请允许浏览器或文件管理器安装未知来源应用。</p>
+          <div class="download-info">
+            <span><strong id="releaseVersion">最新版本</strong><small>版本</small></span>
+            <span><strong id="releaseSize">APK</strong><small>安装包</small></span>
+            <span><strong>Android 6.0+</strong><small>系统要求</small></span>
+          </div>
+        </div>
+        <div class="download-actions">
+          <a class="button button-light" href="https://github.com/waikr/KardLeaf/releases/latest" data-download-link>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 19h14" /></svg>
+            <span><small>GitHub Releases</small><strong>下载 APK</strong></span>
+          </a>
+          <a class="text-link light" href="https://github.com/waikr/KardLeaf/releases" target="_blank" rel="noreferrer">查看历史版本 →</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-brand">
+        <a class="brand" href="#top">
+          <span class="brand-mark" aria-hidden="true">
+            <svg viewBox="0 0 48 48"><path d="M11 8.5h18.5c4.7 0 8.5 3.8 8.5 8.5v22.5H19.5C14.8 39.5 11 35.7 11 31V8.5Z" /><path d="M16.5 31.2c7.8-1.2 12.7-5.9 15.2-14.2-8.6.4-14 5.2-15.2 14.2Z" /><path d="M17 32c3.6-4.3 7.3-7.7 12.9-11.4" /></svg>
+          </span>
+          <span class="brand-copy"><strong>KardLeaf</strong><small>卡叶笔记</small></span>
+        </a>
+        <p>本地优先的 Android Markdown 笔记应用。</p>
+      </div>
+      <div class="footer-links">
+        <div><strong>项目</strong><a href="https://github.com/waikr/KardLeaf">GitHub</a><a href="https://github.com/waikr/KardLeaf/releases">版本发布</a><a href="https://github.com/waikr/KardLeaf/issues">问题反馈</a></div>
+        <div><strong>了解</strong><a href="#features">功能特性</a><a href="#screenshots">界面预览</a><a href="https://github.com/waikr/KardLeaf/blob/main/README.md">使用说明</a></div>
+      </div>
+    </div>
+    <div class="container footer-bottom">
+      <span>© <span id="year"></span> KardLeaf. 基于 Apache License 2.0 开源。</span>
+      <span>Made for writing, built for freedom.</span>
+    </div>
+  </footer>
+
+  <dialog class="lightbox" id="lightbox">
+    <button class="lightbox-close" type="button" aria-label="关闭预览">×</button>
+    <img src="" alt="" />
+    <p></p>
+  </dialog>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,113 @@
+const root = document.documentElement;
+const themeToggle = document.querySelector('#themeToggle');
+const releaseStatus = document.querySelector('#releaseStatus');
+const releaseVersion = document.querySelector('#releaseVersion');
+const releaseSize = document.querySelector('#releaseSize');
+const downloadLinks = document.querySelectorAll('[data-download-link]');
+const downloadTexts = document.querySelectorAll('[data-download-text]');
+
+const savedTheme = localStorage.getItem('kardleaf-theme');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+if (savedTheme === 'dark' || (!savedTheme && prefersDark)) {
+  root.dataset.theme = 'dark';
+}
+
+themeToggle?.addEventListener('click', () => {
+  const nextTheme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+  if (nextTheme === 'dark') {
+    root.dataset.theme = 'dark';
+  } else {
+    delete root.dataset.theme;
+  }
+  localStorage.setItem('kardleaf-theme', nextTheme);
+});
+
+const formatBytes = (bytes) => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return 'APK';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / (1024 ** index)).toFixed(index > 1 ? 1 : 0)} ${units[index]}`;
+};
+
+const formatDate = (value) => {
+  if (!value) return '';
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  }).format(new Date(value));
+};
+
+async function loadLatestRelease() {
+  try {
+    const response = await fetch('https://api.github.com/repos/waikr/KardLeaf/releases/latest', {
+      headers: { Accept: 'application/vnd.github+json' }
+    });
+    if (!response.ok) throw new Error(`GitHub API ${response.status}`);
+
+    const release = await response.json();
+    const apk = release.assets?.find((asset) => asset.name.toLowerCase().endsWith('.apk'));
+    const version = release.name || release.tag_name || '最新版本';
+    const date = formatDate(release.published_at);
+
+    releaseVersion.textContent = version;
+    if (apk) {
+      releaseSize.textContent = formatBytes(apk.size);
+      downloadLinks.forEach((link) => { link.href = apk.browser_download_url; });
+      downloadTexts.forEach((text) => { text.textContent = `下载 ${version}`; });
+      releaseStatus.textContent = `${version}${date ? ` · ${date}` : ''} · ${formatBytes(apk.size)}`;
+    } else {
+      releaseStatus.textContent = `${version}${date ? ` · ${date}` : ''} · 前往 Releases 下载`;
+    }
+  } catch (error) {
+    releaseStatus.textContent = '前往 GitHub Releases 获取最新安装包';
+  }
+}
+
+loadLatestRelease();
+
+document.querySelector('#year').textContent = new Date().getFullYear();
+
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach((entry) => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('visible');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.12 });
+
+document.querySelectorAll('.reveal').forEach((element) => observer.observe(element));
+
+const screenshotTabs = document.querySelectorAll('.screenshot-tab');
+const screenshotCards = document.querySelectorAll('.screenshot-card');
+
+screenshotTabs.forEach((tab) => {
+  tab.addEventListener('click', () => {
+    screenshotTabs.forEach((item) => item.classList.remove('active'));
+    tab.classList.add('active');
+    const filter = tab.dataset.filter;
+    screenshotCards.forEach((card) => {
+      card.classList.toggle('hidden', filter !== 'all' && card.dataset.category !== filter);
+    });
+  });
+});
+
+const lightbox = document.querySelector('#lightbox');
+const lightboxImage = lightbox.querySelector('img');
+const lightboxTitle = lightbox.querySelector('p');
+const lightboxClose = lightbox.querySelector('.lightbox-close');
+
+screenshotCards.forEach((card) => {
+  card.addEventListener('click', () => {
+    lightboxImage.src = card.dataset.image;
+    lightboxImage.alt = card.dataset.title;
+    lightboxTitle.textContent = card.dataset.title;
+    lightbox.showModal();
+  });
+});
+
+lightboxClose.addEventListener('click', () => lightbox.close());
+lightbox.addEventListener('click', (event) => {
+  if (event.target === lightbox) lightbox.close();
+});

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,284 @@
+:root {
+  --bg: #fbfcfa;
+  --surface: #ffffff;
+  --surface-soft: #f2f6f2;
+  --surface-raised: rgba(255, 255, 255, 0.84);
+  --text: #1f2923;
+  --text-soft: #667068;
+  --text-faint: #8b958e;
+  --line: #dfe7e1;
+  --brand: #4c7a62;
+  --brand-strong: #345b47;
+  --brand-soft: #dceadf;
+  --accent: #b66d48;
+  --shadow-sm: 0 8px 30px rgba(31, 41, 35, 0.08);
+  --shadow-lg: 0 30px 70px rgba(35, 61, 46, 0.18);
+  --radius-sm: 16px;
+  --radius: 24px;
+  --radius-lg: 36px;
+  --container: 1180px;
+  color-scheme: light;
+}
+
+[data-theme="dark"] {
+  --bg: #111713;
+  --surface: #18201b;
+  --surface-soft: #141c17;
+  --surface-raised: rgba(24, 32, 27, 0.84);
+  --text: #edf4ef;
+  --text-soft: #abb8af;
+  --text-faint: #7f8d83;
+  --line: #2b372f;
+  --brand: #83b497;
+  --brand-strong: #a7ceb6;
+  --brand-soft: #233a2c;
+  --accent: #dc9974;
+  --shadow-sm: 0 8px 30px rgba(0, 0, 0, 0.2);
+  --shadow-lg: 0 30px 70px rgba(0, 0, 0, 0.35);
+  color-scheme: dark;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  color: var(--text);
+  background: var(--bg);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+body::selection { background: var(--brand-soft); }
+a { color: inherit; text-decoration: none; }
+button, a { -webkit-tap-highlight-color: transparent; }
+button { font: inherit; }
+img { display: block; max-width: 100%; }
+svg { fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+
+.container { width: min(var(--container), calc(100% - 40px)); margin-inline: auto; }
+.skip-link { position: fixed; left: 16px; top: -80px; z-index: 999; padding: 10px 16px; border-radius: 10px; background: var(--text); color: var(--bg); transition: top .2s; }
+.skip-link:focus { top: 16px; }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 74%, transparent);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: blur(20px) saturate(150%);
+}
+.nav-shell { min-height: 76px; display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+.brand { display: inline-flex; align-items: center; gap: 11px; flex-shrink: 0; }
+.brand-mark { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 13px; color: #fff; background: linear-gradient(145deg, var(--brand), var(--brand-strong)); box-shadow: 0 8px 20px color-mix(in srgb, var(--brand) 30%, transparent); }
+.brand-mark svg { width: 29px; height: 29px; stroke-width: 2.1; }
+.brand-mark svg path:first-child { fill: rgba(255,255,255,.08); }
+.brand-copy { display: grid; line-height: 1.12; }
+.brand-copy strong { font-size: 18px; letter-spacing: .01em; }
+.brand-copy small { margin-top: 4px; color: var(--text-soft); font-size: 11px; letter-spacing: .18em; }
+.desktop-nav { display: flex; align-items: center; gap: 6px; margin-left: auto; }
+.desktop-nav a { padding: 9px 14px; border-radius: 12px; color: var(--text-soft); font-size: 14px; font-weight: 650; transition: color .2s, background .2s; }
+.desktop-nav a:hover { color: var(--text); background: var(--surface-soft); }
+.nav-actions { display: flex; align-items: center; gap: 10px; }
+.icon-button { width: 42px; height: 42px; display: grid; place-items: center; padding: 0; border: 1px solid var(--line); border-radius: 13px; color: var(--text-soft); background: var(--surface); cursor: pointer; transition: transform .2s, color .2s, border-color .2s; }
+.icon-button:hover { color: var(--text); border-color: var(--brand); transform: translateY(-1px); }
+.icon-button svg { width: 20px; height: 20px; }
+.moon-icon, [data-theme="dark"] .sun-icon { display: none; }
+[data-theme="dark"] .moon-icon { display: block; }
+.nav-download { padding: 10px 18px; border-radius: 13px; color: #fff; background: var(--brand); font-size: 14px; font-weight: 750; box-shadow: 0 8px 18px color-mix(in srgb, var(--brand) 23%, transparent); transition: transform .2s, background .2s; }
+.nav-download:hover { background: var(--brand-strong); transform: translateY(-1px); }
+
+.hero { position: relative; min-height: 720px; display: grid; align-items: center; overflow: hidden; padding: 80px 0 92px; }
+.hero::before { content: ""; position: absolute; inset: 0; pointer-events: none; background-image: linear-gradient(color-mix(in srgb, var(--line) 34%, transparent) 1px, transparent 1px), linear-gradient(90deg, color-mix(in srgb, var(--line) 34%, transparent) 1px, transparent 1px); background-size: 58px 58px; mask-image: linear-gradient(to bottom, black, transparent 80%); opacity: .35; }
+.hero-glow { position: absolute; border-radius: 50%; filter: blur(2px); pointer-events: none; }
+.hero-glow-one { width: 540px; height: 540px; left: -240px; top: -220px; background: radial-gradient(circle, color-mix(in srgb, var(--brand-soft) 92%, transparent), transparent 70%); }
+.hero-glow-two { width: 480px; height: 480px; right: -210px; bottom: -160px; background: radial-gradient(circle, color-mix(in srgb, #eadfd7 80%, transparent), transparent 70%); }
+[data-theme="dark"] .hero-glow-two { opacity: .18; }
+.hero-grid { position: relative; display: grid; grid-template-columns: .95fr 1.05fr; align-items: center; gap: 90px; }
+.hero-copy { max-width: 650px; }
+.eyebrow { display: inline-flex; align-items: center; gap: 10px; margin-bottom: 22px; color: var(--brand-strong); font-size: 13px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.eyebrow span { width: 30px; height: 1px; background: currentColor; }
+.hero h1 { margin: 0; font-size: clamp(48px, 6vw, 78px); line-height: 1.08; letter-spacing: -.055em; font-weight: 860; }
+.hero h1 span { color: var(--brand); }
+.hero-description { max-width: 610px; margin: 28px 0 0; color: var(--text-soft); font-size: 18px; line-height: 1.85; }
+.hero-actions { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 36px; }
+.button { min-height: 58px; display: inline-flex; align-items: center; justify-content: center; gap: 12px; padding: 12px 21px; border: 1px solid transparent; border-radius: 17px; font-weight: 750; transition: transform .2s, box-shadow .2s, background .2s, border-color .2s; }
+.button:hover { transform: translateY(-2px); }
+.button svg { width: 22px; height: 22px; }
+.button span { display: grid; line-height: 1.2; }
+.button span small { margin-bottom: 3px; font-size: 10px; font-weight: 650; opacity: .72; }
+.button span strong { font-size: 15px; }
+.button-primary { color: #fff; background: var(--brand); box-shadow: 0 14px 30px color-mix(in srgb, var(--brand) 28%, transparent); }
+.button-primary:hover { background: var(--brand-strong); box-shadow: 0 18px 38px color-mix(in srgb, var(--brand) 34%, transparent); }
+.button-secondary { color: var(--text); background: var(--surface); border-color: var(--line); box-shadow: var(--shadow-sm); }
+.button-secondary:hover { border-color: var(--brand); }
+.release-meta { display: flex; align-items: center; gap: 9px; margin-top: 20px; color: var(--text-soft); font-size: 13px; }
+.status-dot { width: 8px; height: 8px; border-radius: 50%; background: #48a36e; box-shadow: 0 0 0 5px color-mix(in srgb, #48a36e 14%, transparent); }
+.hero-badges { display: flex; flex-wrap: wrap; gap: 9px; margin-top: 26px; }
+.hero-badges span { padding: 7px 11px; border: 1px solid var(--line); border-radius: 999px; color: var(--text-soft); background: color-mix(in srgb, var(--surface) 78%, transparent); font-size: 12px; font-weight: 700; }
+
+.hero-visual { position: relative; min-height: 580px; display: grid; place-items: center; }
+.visual-orbit { position: absolute; border: 1px solid color-mix(in srgb, var(--brand) 21%, transparent); border-radius: 50%; }
+.orbit-one { width: 470px; height: 470px; }
+.orbit-two { width: 360px; height: 360px; border-style: dashed; animation: spin 38s linear infinite; }
+.phone { position: absolute; overflow: hidden; padding: 8px; border: 1px solid color-mix(in srgb, #fff 60%, var(--line)); border-radius: 38px; background: #202620; box-shadow: var(--shadow-lg); }
+.phone-screen { width: 100%; height: 100%; overflow: hidden; border-radius: 31px; background: #f3f4f1; }
+.phone-screen img { width: 100%; height: 100%; object-fit: cover; object-position: top center; }
+.phone-front { z-index: 3; width: 268px; height: 548px; transform: rotate(-2deg) translateX(34px); }
+.phone-back { z-index: 2; width: 235px; height: 482px; opacity: .9; transform: rotate(10deg) translate(-90px, 32px); filter: saturate(.78); }
+.phone-camera { position: absolute; z-index: 2; top: 14px; left: 50%; width: 72px; height: 19px; transform: translateX(-50%); border-radius: 999px; background: #171b17; }
+.floating-card { position: absolute; z-index: 5; display: flex; align-items: center; gap: 11px; min-width: 178px; padding: 12px 15px; border: 1px solid color-mix(in srgb, var(--line) 70%, transparent); border-radius: 16px; background: var(--surface-raised); box-shadow: var(--shadow-sm); backdrop-filter: blur(16px); }
+.floating-card-top { top: 72px; right: -12px; animation: float 5s ease-in-out infinite; }
+.floating-card-bottom { bottom: 64px; left: -4px; animation: float 5s ease-in-out 1.4s infinite; }
+.floating-card span:last-child { display: grid; line-height: 1.2; }
+.floating-card strong { font-size: 13px; }
+.floating-card small { margin-top: 4px; color: var(--text-soft); font-size: 10px; }
+.floating-icon { width: 34px; height: 34px; display: grid; place-items: center; border-radius: 11px; color: #fff; background: var(--brand); font-weight: 900; }
+
+.trust-strip { border-block: 1px solid var(--line); background: var(--surface); }
+.trust-grid { display: grid; grid-template-columns: repeat(4, 1fr); }
+.trust-grid div { position: relative; display: grid; justify-items: center; padding: 25px 18px; text-align: center; }
+.trust-grid div:not(:last-child)::after { content: ""; position: absolute; right: 0; top: 26%; width: 1px; height: 48%; background: var(--line); }
+.trust-grid strong { font-size: 14px; }
+.trust-grid span { margin-top: 4px; color: var(--text-soft); font-size: 12px; }
+
+.section { padding: 112px 0; }
+.section-soft { background: var(--surface-soft); }
+.section-heading { display: flex; align-items: end; justify-content: space-between; gap: 50px; margin-bottom: 50px; }
+.section-heading h2 { margin: 8px 0 0; font-size: clamp(36px, 5vw, 55px); line-height: 1.14; letter-spacing: -.045em; }
+.section-heading p { max-width: 510px; margin: 0 0 5px; color: var(--text-soft); font-size: 16px; }
+.section-heading.centered { display: grid; justify-items: center; text-align: center; }
+.section-heading.centered p { margin: 0; }
+.section-kicker { color: var(--brand); font-size: 12px; font-weight: 850; letter-spacing: .16em; text-transform: uppercase; }
+.section-kicker.light { color: #cfe3d6; }
+
+.feature-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+.feature-card { position: relative; min-height: 300px; overflow: hidden; padding: 30px; border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); box-shadow: 0 1px 0 rgba(255,255,255,.4) inset; transition: transform .25s, box-shadow .25s, border-color .25s; }
+.feature-card:hover { transform: translateY(-5px); border-color: color-mix(in srgb, var(--brand) 42%, var(--line)); box-shadow: var(--shadow-sm); }
+.feature-card-wide { grid-row: span 2; min-height: 620px; background: linear-gradient(155deg, var(--surface), var(--brand-soft)); }
+.feature-card-accent { color: #f6fbf7; background: linear-gradient(145deg, var(--brand), var(--brand-strong)); border-color: transparent; }
+.feature-card-accent p { color: rgba(255,255,255,.78); }
+.feature-card-accent .feature-number { color: rgba(255,255,255,.22); }
+.feature-card-accent .feature-icon { color: var(--brand-strong); background: rgba(255,255,255,.92); }
+.feature-number { position: absolute; right: 24px; top: 20px; color: color-mix(in srgb, var(--text) 12%, transparent); font-size: 54px; line-height: 1; font-weight: 900; letter-spacing: -.06em; }
+.feature-icon { width: 50px; height: 50px; display: grid; place-items: center; border-radius: 16px; color: var(--brand); background: var(--brand-soft); }
+.feature-icon svg { width: 25px; height: 25px; }
+.feature-card h3 { margin: 46px 0 12px; font-size: 22px; letter-spacing: -.02em; }
+.feature-card p { margin: 0; color: var(--text-soft); font-size: 14px; line-height: 1.82; }
+.mini-code { position: absolute; inset: auto 30px 30px; display: grid; gap: 10px; padding: 22px; border: 1px solid color-mix(in srgb, var(--brand) 20%, transparent); border-radius: 17px; color: var(--brand-strong); background: color-mix(in srgb, var(--surface) 74%, transparent); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; box-shadow: var(--shadow-sm); }
+
+.screenshot-tabs { display: flex; justify-content: center; gap: 8px; margin: -15px 0 38px; }
+.screenshot-tab { padding: 9px 17px; border: 1px solid var(--line); border-radius: 999px; color: var(--text-soft); background: var(--surface); cursor: pointer; transition: color .2s, background .2s, border-color .2s; }
+.screenshot-tab:hover, .screenshot-tab.active { color: #fff; background: var(--brand); border-color: var(--brand); }
+.screenshot-grid { display: grid; grid-template-columns: repeat(6, 1fr); align-items: start; gap: 16px; }
+.screenshot-card { grid-column: span 2; position: relative; overflow: hidden; padding: 0; border: 0; border-radius: 22px; background: var(--surface); box-shadow: var(--shadow-sm); cursor: zoom-in; transition: transform .25s, opacity .25s; }
+.screenshot-card:nth-child(1), .screenshot-card:nth-child(4) { transform: translateY(22px); }
+.screenshot-card:hover { transform: translateY(-5px) scale(1.01); }
+.screenshot-card:nth-child(1):hover, .screenshot-card:nth-child(4):hover { transform: translateY(17px) scale(1.01); }
+.screenshot-card img { width: 100%; aspect-ratio: 9 / 18.5; object-fit: cover; object-position: top; }
+.screenshot-card span { position: absolute; inset: auto 12px 12px; padding: 10px 13px; border-radius: 12px; color: #fff; background: rgba(20, 27, 22, .72); font-size: 12px; font-weight: 750; text-align: left; backdrop-filter: blur(9px); }
+.screenshot-card.hidden { display: none; }
+
+.download-section { padding-top: 90px; }
+.download-card { position: relative; display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 60px; overflow: hidden; padding: 58px 62px; border-radius: var(--radius-lg); color: #f7fbf8; background: linear-gradient(135deg, #355a47, #527f66 58%, #466f59); box-shadow: var(--shadow-lg); }
+.download-pattern { position: absolute; inset: 0; opacity: .16; background-image: radial-gradient(circle at 1px 1px, #fff 1px, transparent 0); background-size: 24px 24px; mask-image: linear-gradient(90deg, transparent, #000 42%, #000); }
+.download-copy, .download-actions { position: relative; z-index: 1; }
+.download-copy h2 { max-width: 700px; margin: 10px 0 14px; font-size: clamp(35px, 5vw, 54px); line-height: 1.12; letter-spacing: -.045em; }
+.download-copy > p { max-width: 680px; margin: 0; color: rgba(255,255,255,.74); }
+.download-info { display: flex; flex-wrap: wrap; gap: 34px; margin-top: 28px; }
+.download-info span { display: grid; }
+.download-info strong { font-size: 15px; }
+.download-info small { margin-top: 3px; color: rgba(255,255,255,.58); font-size: 11px; }
+.download-actions { display: grid; justify-items: center; gap: 16px; min-width: 225px; }
+.button-light { min-width: 220px; color: var(--brand-strong); background: #fff; box-shadow: 0 14px 32px rgba(0,0,0,.15); }
+.text-link { font-size: 13px; font-weight: 750; }
+.text-link.light { color: rgba(255,255,255,.75); }
+.text-link:hover { color: #fff; }
+
+.site-footer { padding: 72px 0 28px; border-top: 1px solid var(--line); background: var(--surface); }
+.footer-grid { display: grid; grid-template-columns: 1fr auto; gap: 70px; }
+.footer-brand p { margin: 18px 0 0; color: var(--text-soft); font-size: 14px; }
+.footer-links { display: grid; grid-template-columns: repeat(2, minmax(130px, 1fr)); gap: 60px; }
+.footer-links div { display: grid; align-content: start; gap: 9px; }
+.footer-links strong { margin-bottom: 4px; font-size: 13px; }
+.footer-links a { color: var(--text-soft); font-size: 13px; }
+.footer-links a:hover { color: var(--brand); }
+.footer-bottom { display: flex; justify-content: space-between; gap: 30px; margin-top: 52px; padding-top: 24px; border-top: 1px solid var(--line); color: var(--text-faint); font-size: 11px; }
+
+.lightbox { width: min(440px, calc(100% - 30px)); max-height: 92vh; overflow: visible; padding: 0; border: 0; border-radius: 24px; background: transparent; box-shadow: none; }
+.lightbox::backdrop { background: rgba(7, 10, 8, .78); backdrop-filter: blur(8px); }
+.lightbox img { width: 100%; max-height: 84vh; object-fit: contain; border-radius: 22px; box-shadow: 0 30px 90px rgba(0,0,0,.4); }
+.lightbox p { margin: 12px 0 0; color: #fff; text-align: center; font-size: 13px; }
+.lightbox-close { position: absolute; z-index: 2; right: -14px; top: -14px; width: 38px; height: 38px; border: 0; border-radius: 50%; color: #111; background: #fff; font-size: 24px; line-height: 1; cursor: pointer; box-shadow: 0 8px 24px rgba(0,0,0,.25); }
+
+.reveal { opacity: 0; transform: translateY(22px); transition: opacity .7s ease, transform .7s ease; }
+.reveal.visible { opacity: 1; transform: translateY(0); }
+
+@keyframes float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-9px); } }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 1050px) {
+  .hero-grid { gap: 40px; }
+  .hero-visual { transform: scale(.9); }
+  .floating-card-top { right: 8px; }
+  .feature-grid { grid-template-columns: repeat(2, 1fr); }
+  .feature-card-wide { grid-row: span 1; min-height: 340px; }
+  .mini-code { position: static; margin-top: 28px; }
+  .download-card { grid-template-columns: 1fr; }
+  .download-actions { justify-items: start; }
+}
+
+@media (max-width: 820px) {
+  .desktop-nav { display: none; }
+  .hero { padding-top: 48px; }
+  .hero-grid { grid-template-columns: 1fr; }
+  .hero-copy { order: -1; max-width: none; text-align: center; }
+  .eyebrow, .hero-actions, .hero-badges, .release-meta { justify-content: center; }
+  .hero-description { margin-inline: auto; }
+  .hero-visual { min-height: 530px; }
+  .trust-grid { grid-template-columns: repeat(2, 1fr); }
+  .trust-grid div:nth-child(2)::after { display: none; }
+  .trust-grid div:nth-child(-n+2) { border-bottom: 1px solid var(--line); }
+  .section-heading { display: grid; gap: 22px; }
+  .screenshot-grid { grid-template-columns: repeat(2, 1fr); }
+  .screenshot-card { grid-column: span 1; }
+  .screenshot-card:nth-child(1), .screenshot-card:nth-child(4) { transform: none; }
+  .screenshot-card:nth-child(1):hover, .screenshot-card:nth-child(4):hover { transform: translateY(-5px) scale(1.01); }
+}
+
+@media (max-width: 620px) {
+  .container { width: min(100% - 26px, var(--container)); }
+  .nav-shell { min-height: 66px; }
+  .brand-mark { width: 38px; height: 38px; }
+  .brand-copy small { display: none; }
+  .nav-download { display: none; }
+  .hero { min-height: auto; padding: 54px 0 70px; }
+  .hero h1 { font-size: clamp(42px, 13vw, 58px); }
+  .hero-description { font-size: 16px; }
+  .hero-actions { display: grid; }
+  .button { width: 100%; }
+  .hero-visual { min-height: 455px; transform: scale(.78); margin: -35px 0; }
+  .floating-card-top { right: -40px; }
+  .floating-card-bottom { left: -42px; }
+  .trust-grid div { padding: 20px 10px; }
+  .section { padding: 82px 0; }
+  .section-heading { margin-bottom: 38px; }
+  .feature-grid { grid-template-columns: 1fr; }
+  .feature-card, .feature-card-wide { min-height: auto; }
+  .feature-card-wide { padding-bottom: 30px; }
+  .screenshot-tabs { justify-content: flex-start; overflow-x: auto; padding-bottom: 6px; }
+  .screenshot-tab { flex: 0 0 auto; }
+  .screenshot-grid { gap: 11px; }
+  .screenshot-card { border-radius: 16px; }
+  .screenshot-card span { inset: auto 7px 7px; padding: 8px 9px; font-size: 10px; }
+  .download-card { gap: 35px; padding: 39px 27px; border-radius: 26px; }
+  .download-info { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+  .download-actions, .button-light { width: 100%; }
+  .footer-grid { grid-template-columns: 1fr; }
+  .footer-links { gap: 25px; }
+  .footer-bottom { display: grid; gap: 8px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+  .reveal { opacity: 1; transform: none; }
+}


### PR DESCRIPTION
## 修改内容

- 在 `docs/` 下新增 KardLeaf 单页官网
- 参考 AList 文档首页的清爽布局，但重新设计为 KardLeaf 的卡片与叶片视觉风格
- 首页展示应用截图、核心功能、隐私与本地文件特性
- 自动读取 GitHub Releases 最新版本，并将下载按钮直连最新 APK
- 支持深色模式、移动端响应式布局、截图筛选与大图预览
- 复用仓库现有 `docs/images/` 截图，不新增重复图片资源
- 添加 `.nojekyll`，可直接使用 GitHub Pages 的 `main /docs` 方式发布

## 验证

- HTML 已完成静态解析检查
- JavaScript 已通过 `node --check`
- 已检查页面引用的截图路径均来自仓库现有文档图片
- 未执行 Gradle 编译，本次仅新增静态网站文件